### PR TITLE
activesupport requires Ruby version >= 2.2.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.1
+  - 2.2
 script:
   - bundle exec jekyll build


### PR DESCRIPTION
Gem::InstallError: activesupport requires Ruby version >= 2.2.2.