### PR TITLE
better presentation of former lab members

### DIFF
--- a/team.md
+++ b/team.md
@@ -5,14 +5,17 @@ title: Team
 
 Name                                | Position        | Link
 ------------------------------------|-----------------|-----------------
-~~Peter Krawitz, Dr.med, Dipl. Phys.~~  |                 | [Grouppage GPI-Anchor Deficiencies](http://krawitz.charite.de/)
 Marie Coutelier, MD, Phd            | Postdoc         |
-~~Marten Jäger, M.Sc.~~                 | PhD Student     | [Home](team_jaeger.html) / [GitHub](https://github.com/martenj)
 Peter Hansen , M.Sc.                | PhD Student     | [GitHub](https://github.com/hansenp)
-~~Leon Kuchenbecker, M.Sc.~~          | PhD Student     | [GitHub](https://github.com/lkuchenb)
-~~Max Schubach, M.Sc.~~                | PhD Student     | [Home](team_schubach.html) / [GitHub](https://github.com/visze)
 Layal Abo Khayal                    | PhD Student     | 
 Martin Attah Mensah, Dr. med        |                 | 
 Tori Jean Pantel                    | Student         | 
-~~Sofia Ånäs ~~                         | Student         | 
+
+# Former Lab Members
+* Peter Krawitz, Dr.med, Dipl. Phys
+* Marten Jäger, M.Sc. (PhD Student)
+* Leon Kuchenbecker, M.Sc. (PhD Student)
+* Max Schubach, M.Sc. (PhD Student)
+* Sofia Ånäs (Master Student)
+
 


### PR DESCRIPTION
Normally former members are not crossed out but listed in a new section (former lab members)

This looks much nicer than my name with a line cross though